### PR TITLE
Update README.md

### DIFF
--- a/exercises/14-Loop-dictionary/README.md
+++ b/exercises/14-Loop-dictionary/README.md
@@ -7,8 +7,6 @@ list = ["a","b","c"]
 dictionary = { "one": "a", "two": "b", "three": "c"}
 ```
 
-![Python list vs dict](https://ucarecdn.com/4671e04e-651d-4434-a01a-f019dddfb2d2/)
-
 ## Retrieve dictonary values (very similar to lists)
 
 ```python


### PR DESCRIPTION
- Removed "Python list vs dict" image URL, file not found.

Cannot find a clear image depicting the two to replace, in the meantime, no image provided.