### PR TITLE
Update README to clarify for loop requirement in exercise 08

### DIFF
--- a/exercises/08-Delete_element/README.es.md
+++ b/exercises/08-Delete_element/README.es.md
@@ -5,6 +5,7 @@ La única forma de borrar a `Daniella` de la lista (sin trampas) sería crear un
 ## 📝 Instrucciones:
 
 1. Por favor, crea una función `delete_person` que elimine a una persona dada de una lista y devuelva una nueva lista sin esa persona.
+2. Aunque hay diferentes formas de conseguir el resultado esperado, en este ejercicio queremos que iteres con el bucle `for`.
 
 ## 💻 Resultado esperado:
 

--- a/exercises/08-Delete_element/README.md
+++ b/exercises/08-Delete_element/README.md
@@ -5,6 +5,7 @@ The only way to delete `Daniella` from the list (without cheating) would be to c
 ## 📝 Instructions:
 
 1. Please create a `delete_person` function that deletes any given person from the list and returns a new list without that person.
+2. Although there are different ways to achieve the expected result in this exercise we want you to iterate using a `for` loop.
 
 ## 💻 Expected result:
 


### PR DESCRIPTION
The automated test for this exercise strictly requires the use of a for loop which was not specified in the original instructions. This inconsistency caused valid solutions using native Python methods to fail the test. In fact, if the exercise is solved using the exact same approach as the official solution.hide.py file, the automated test explicitly throws an error requesting the use of a for loop because it was omitted. To resolve this issue I have added an explicit instruction clarifying the for loop requirement in both the English and Spanish README files.
